### PR TITLE
Typo, 1 of 2 instead of 1 on 2

### DIFF
--- a/client/main.html
+++ b/client/main.html
@@ -77,7 +77,7 @@
   <div class="container">
     <div class="row">
       <div class="col-sm-offset-2 col-sm-8 col-xs-12">
-        <p>{{hitsLength}} on {{this.nbHits}} results found in {{this.processingTimeMS}}ms {{#if currentUser}}({{packageCount}}){{/if}}</p>
+        <p>{{hitsLength}} of {{this.nbHits}} results found in {{this.processingTimeMS}}ms {{#if currentUser}}({{packageCount}}){{/if}}</p>
         {{#each this.hits}}
           {{> searchResult}}
         {{/each}}


### PR DESCRIPTION
Minor grammar typo. Showing "10 of 30 results" rather than "showing 10 on 30 results".